### PR TITLE
Added more scammer usernames from my channel

### DIFF
--- a/SpamAccountsList.txt
+++ b/SpamAccountsList.txt
@@ -45,3 +45,11 @@ rendletech
 ethicalhacker_funds
 sactacrack
 BenGraham75
+Clihackstools on Instagram
+AIMTOOLZ on Instagram
+wãtsáp➕❶❾⓿❸❻❶❺❽⓿❽❾
+Chrixhack
+CREDHACKS
+BYTEUNLOCK
+Kelvin Joe
+willcracks


### PR DESCRIPTION
My channel is iOS related so these are iCloud Unlock / jailbreak scammers who advertise WhatsApp or Instagram account of theirs.